### PR TITLE
Working on mcs

### DIFF
--- a/include/mcs.h
+++ b/include/mcs.h
@@ -100,13 +100,10 @@ typedef struct mcs_lock_local
 #endif
 } mcs_lock_local_t;
 
-#define MCS_LOCK_INITIALIZER { .waiting = 0, .next = NULL, .local = { 0 } }
-
-
 extern __thread mcs_lock_local_t __mcs_local;
 
 static inline mcs_lock_t*
-mcs_get_local(lock)
+mcs_get_local()
 {
   return (mcs_lock_t*) &__mcs_local;
 }
@@ -128,7 +125,7 @@ mcs_lock_trylock(mcs_lock_t* lock)
 static inline int
 mcs_lock_lock(mcs_lock_t* lock) 
 {
-  volatile mcs_lock_t* local = mcs_get_local(lock);
+  volatile mcs_lock_t* local = mcs_get_local();
   local->next = NULL;
   
   mcs_lock_t* pred = swap_ptr((void*) &lock->next, (void*) local);

--- a/src/queue-ms_lb/queue-lock.c
+++ b/src/queue-ms_lb/queue-lock.c
@@ -70,6 +70,8 @@ queue_new()
   node->next = NULL;
   set->head = node;
   set->tail = node;
+  INIT_LOCK(&(set->head_lock));
+  INIT_LOCK(&(set->tail_lock));
 
   return set;
 }


### PR DESCRIPTION
Due to the fact that the head and tail locks were not initialized, running `lb-qu_ms` with `valgrind` was giving the following warnings:

```
==21848== Thread 2:
==21848== Conditional jump or move depends on uninitialised value(s)
==21848==    at 0x402E8C: mcs_lock_lock (mcs.h:133)
==21848==    by 0x402E8C: queue_ms_insert (queue-ms.c:47)
==21848==    by 0x403393: test (test_simple.c:191)
==21848==    by 0x4E3F183: start_thread (pthread_create.c:312)
==21848==    by 0x514F37C: clone (clone.S:111)
==21848==
#BEFORE size is: 1024
==21848== Conditional jump or move depends on uninitialised value(s)
==21848==    at 0x402F3B: mcs_lock_lock (mcs.h:133)
==21848==    by 0x402F3B: queue_ms_delete (queue-ms.c:59)
==21848==    by 0x403607: test (test_simple.c:214)
==21848==    by 0x4E3F183: start_thread (pthread_create.c:312)
==21848==    by 0x514F37C: clone (clone.S:111)
```

It seems that `next` field of the MCS lock is initialized to `NULL` by default due to optimizations (`-O3`) used, but I think this is not the case in general. For instance, compiling the following code with `gcc code.c` and running it on lpd48core gives `0 0x7ffef94791a0`, but by compiling with `gcc -O3 code.c` gives `1 (nil)`.

```
struct foo {
  int * x;
};

int main()
{
  struct foo y;
  printf("%d %p\n", y.x == NULL, y.x);
  return 0;
}
```